### PR TITLE
Use `IndexMap` to preserve insertion ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ starknet-types-core = { version = "0.1.7", default-features = false, features = 
 rocksdb = { optional = true, version = "0.22", features = [
   "multi-threaded-cf",
 ] }
+indexmap = "2.2.6"
 
 [dev-dependencies]
 env_logger = "0.11.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.195", default-features = false, features = [
   "derive",
   "alloc",
 ] }
-starknet-types-core = { version = "0.1.8", default-features = false, features = [
+starknet-types-core = { version = "0.2", default-features = false, features = [
   "hash",
   "parity-scale-codec",
   "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.195", default-features = false, features = [
   "derive",
   "alloc",
 ] }
-starknet-types-core = { version = "0.1.7", default-features = false, features = [
+starknet-types-core = { version = "0.1.8", default-features = false, features = [
   "hash",
   "parity-scale-codec",
   "alloc",

--- a/src/trie/proof.rs
+++ b/src/trie/proof.rs
@@ -11,10 +11,11 @@ use crate::{
         merkle_node::{Node, NodeHandle},
         tree::NodeKey,
     },
-    BitSlice, BitVec, BonsaiDatabase, BonsaiStorageError, HashMap, HashSet,
+    BitSlice, BitVec, BonsaiDatabase, BonsaiStorageError, HashSet,
 };
 use core::{marker::PhantomData, mem};
 use hashbrown::hash_set;
+use indexmap::IndexMap;
 use starknet_types_core::{felt::Felt, hash::StarkHash};
 
 #[derive(Debug, thiserror::Error)]
@@ -58,7 +59,7 @@ impl ProofNode {
 }
 
 #[derive(Debug, Clone)]
-pub struct MultiProof(pub HashMap<Felt, ProofNode>);
+pub struct MultiProof(pub IndexMap<Felt, ProofNode>);
 impl MultiProof {
     /// If the proof proves more than just the provided `key_values`, this function will not fail.
     /// Not the most optimized way of doing it, but we don't actually need to verify proofs in madara.


### PR DESCRIPTION
This is so that when we return the `MultiProof` value from the RPC, the resultant list will be ordered from root to leaves. This is mainly to support using `pathfinder` proofs verification logic in `snos` where the nodes are not paired with its hash and are assumed to be arranged in the certain order.

https://github.com/cartridge-gg/snos/blob/811f2201516d9430c28d94c97ff2902ba9adf86a/crates/rpc-client/src/pathfinder/proofs.rs#L109-L126

**TODO**: add more elaboration for future reference