### PR TITLE
Update `starknet-types-core` to `0.2.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.195", default-features = false, features = [
   "derive",
   "alloc",
 ] }
-starknet-types-core = { version = "0.1.8", default-features = false, features = [
+starknet-types-core = { version = "=0.2.2", default-features = false, features = [
   "hash",
   "parity-scale-codec",
   "alloc",


### PR DESCRIPTION
## Summary
- Bump `starknet-types-core` dependency from 0.1.7 to =0.2.2

## Test plan
- [ ] Verify the project builds successfully with the updated dependency
- [ ] Run existing tests to ensure compatibility
- [ ] Check for any API changes or deprecations in the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)